### PR TITLE
Use Lang enumeration instead of importing another package i.e. riot.Lang

### DIFF
--- a/sansa-rdf-flink/src/main/scala/net/sansa_stack/rdf/flink/io/package.scala
+++ b/sansa-rdf-flink/src/main/scala/net/sansa_stack/rdf/flink/io/package.scala
@@ -10,16 +10,16 @@ import net.sansa_stack.rdf.flink.io.nquads.NQuadsReader
 import net.sansa_stack.rdf.flink.io.ntriples.NTriplesReader
 import org.apache.flink.api.common.functions.RichMapPartitionFunction
 import org.apache.flink.api.java.operators.DataSink
-import org.apache.flink.api.scala.{ DataSet, ExecutionEnvironment }
+import org.apache.flink.api.scala.{DataSet, ExecutionEnvironment}
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.core.fs.FileSystem
 import org.apache.flink.hadoopcompatibility.scala.HadoopInputs
 import org.apache.flink.streaming.api.scala._
 import org.apache.flink.util.Collector
-import org.apache.hadoop.io.{ LongWritable, Text }
+import org.apache.hadoop.io.{LongWritable, Text}
 import org.apache.hadoop.mapreduce.lib.input.TextInputFormat
-import org.apache.jena.graph.{ NodeFactory, Triple }
-import org.apache.jena.riot.{ Lang, RDFDataMgr }
+import org.apache.jena.graph.{NodeFactory, Triple}
+import org.apache.jena.riot.RDFDataMgr
 import org.apache.jena.sparql.core.Quad
 
 /**
@@ -28,7 +28,7 @@ import org.apache.jena.sparql.core.Quad
  */
 package object io {
 
-  object RDFLang extends Enumeration {
+  object Lang extends Enumeration {
     val NTRIPLES, NQUADS, TURTLE, RDFXML = Value
   }
 
@@ -216,12 +216,12 @@ package object io {
      * @param lang the RDF language (N-Triples, N-Quads, Turtle)
      * @return the [[DataSet]]
      */
-    def rdf(lang: Lang, allowBlankLines: Boolean = false): String => DataSet[Triple] = lang match {
+    def rdf(lang: Lang.Value, allowBlankLines: Boolean = false): String => DataSet[Triple] = lang match {
       case i if lang == Lang.NTRIPLES => ntriples(allowBlankLines)
       case j if lang == Lang.TURTLE => turtle
       case k if lang == Lang.RDFXML => rdfxml
       case g if lang == Lang.NQUADS => nquads(allowBlankLines)
-      case _ => throw new IllegalArgumentException(s"${lang.getLabel} syntax not supported yet!")
+      case _ => throw new IllegalArgumentException(s"${lang} syntax not supported yet!")
     }
 
     /**
@@ -315,7 +315,7 @@ package object io {
           // collect the parsed triples
           val is = ReadableByteChannelFromIterator.toInputStream(it)
           RDFDataMgr
-            .createIteratorTriples(is, Lang.TURTLE, null).asScala
+            .createIteratorTriples(is, org.apache.jena.riot.Lang.TURTLE, null).asScala
             .foreach(t => collector.collect(t))
         }
       })

--- a/sansa-rdf-flink/src/main/scala/net/sansa_stack/rdf/flink/model/graph/GraphOps.scala
+++ b/sansa-rdf-flink/src/main/scala/net/sansa_stack/rdf/flink/model/graph/GraphOps.scala
@@ -1,27 +1,29 @@
 package net.sansa_stack.rdf.flink.model.graph
 
-import org.apache.flink.api.scala.{ DataSet, _ }
-import org.apache.flink.graph.{ Edge, Vertex }
+import net.sansa_stack.rdf.flink.utils.NodeKey
+import org.apache.flink.api.scala.{DataSet, _}
+import org.apache.flink.graph.{Edge, Vertex}
 import org.apache.flink.graph.scala._
-import org.apache.jena.graph.{ Node, NodeFactory, Triple }
+import org.apache.jena.graph.{Node, NodeFactory, Triple}
 
 /**
- * Flink/Gelly based implementation of DataSet[Triple].
- *
- * @author Gezim Sejdiu
- */
+  * Flink/Gelly based implementation of DataSet[Triple].
+  *
+  * @author Gezim Sejdiu
+  */
 object GraphOps {
 
   @transient var env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
 
   /**
-   * Constructs Gelly graph from DataSet of triples
-   * @param triples DataSet of triples
-   * @return object of Graph which contains the constructed  ''graph''.
-   */
+    * Constructs Gelly graph from DataSet of triples
+    *
+    * @param triples DataSet of triples
+    * @return object of Graph which contains the constructed  ''graph''.
+    */
   def constructGraph(triples: DataSet[Triple]): Graph[Long, Node, Node] = {
 
-    val vertexIDs: DataSet[(Node, Long)] = (triples.map(_.getSubject) union triples.map(_.getObject)).distinct.map(f => (f, f.getURI.toLong)) // indexing
+    val vertexIDs: DataSet[(Node, Long)] = (triples.map(f => NodeKey(f.getSubject)) union triples.map(f => NodeKey(f.getObject))).distinct(f => f.hashCode()).map(f => (NodeKey(f), NodeKey(f).node.getURI.toLong)) // indexing
 
     val vertices: DataSet[(Long, Node)] = vertexIDs.map(x => (x._2, x._1))
 
@@ -45,61 +47,67 @@ object GraphOps {
   }
 
   /**
-   * Convert a graph into a DataSet of Triple.
-   * @param graph Gelly graph of triples.
-   * @return a DataSet of triples.
-   */
+    * Convert a graph into a DataSet of Triple.
+    *
+    * @param graph Gelly graph of triples.
+    * @return a DataSet of triples.
+    */
   def toDataSet(graph: Graph[Long, Node, Node]): DataSet[Triple] = {
     graph.getTriplets() map (x => (Triple.create(x.getSrcVertex.getValue, x.getEdge.getValue, x.getTrgVertex.getValue)))
   }
 
   /**
-   * Get triples  of a given graph.
-   * @param graph one instance of the given graph
-   * @return [[DataSet[Triple]]] which contains list of the graph triples.
-   */
+    * Get triples  of a given graph.
+    *
+    * @param graph one instance of the given graph
+    * @return [[DataSet[Triple]]] which contains list of the graph triples.
+    */
   def getTriples(graph: Graph[Long, Node, Node]): DataSet[Triple] =
     toDataSet(graph)
 
   /**
-   * Get subjects from a given graph.
-   * @param graph one instance of the given graph
-   * @return [[DataSet[Node]]] which contains list of the subjects.
-   */
+    * Get subjects from a given graph.
+    *
+    * @param graph one instance of the given graph
+    * @return [[DataSet[Node]]] which contains list of the subjects.
+    */
   def getSubjects(graph: Graph[Long, Node, Node]): DataSet[Node] =
     graph.getTriplets.map(_.getSrcVertex.getValue)
 
   /**
-   * Get predicates from a given graph.
-   * @param graph one instance of the given graph
-   * @return [[DataSet[Node]]] which contains list of the predicates.
-   */
+    * Get predicates from a given graph.
+    *
+    * @param graph one instance of the given graph
+    * @return [[DataSet[Node]]] which contains list of the predicates.
+    */
   def getPredicates(graph: Graph[Long, Node, Node]): DataSet[Node] =
     graph.getTriplets.map(_.getEdge.getValue)
 
   /**
-   * Get objects from a given graph.
-   * @param graph one instance of the given graph
-   * @return [[DataSet[Node]]] which contains list of the objects.
-   */
+    * Get objects from a given graph.
+    *
+    * @param graph one instance of the given graph
+    * @return [[DataSet[Node]]] which contains list of the objects.
+    */
   def getObjects(graph: Graph[Long, Node, Node]): DataSet[Node] =
     graph.getTriplets.map(_.getTrgVertex.getValue)
 
   /**
-   * Compute the size of the graph
-   * @param graph
-   * @return the number of edges in the graph.
-   */
+    * Compute the size of the graph
+    *
+    * @param graph
+    * @return the number of edges in the graph.
+    */
   def size(graph: Graph[Long, Node, Node]): Long =
     graph.getEdges.count()
 
   /**
-   * Return the union of this graph and another one.
-   *
-   * @param graph of the graph
-   * @param other of the other graph
-   * @return graph (union of all)
-   */
+    * Return the union of this graph and another one.
+    *
+    * @param graph of the graph
+    * @param other of the other graph
+    * @return graph (union of all)
+    */
   def union(graph: Graph[Long, Node, Node], other: Graph[Long, Node, Node]): Graph[Long, Node, Node] = {
     Graph.fromDataSet(graph.getVertices.union(other.getVertices.distinct()), graph.getEdges.union(other.getEdges.distinct()), env)
   }

--- a/sansa-rdf-flink/src/main/scala/net/sansa_stack/rdf/flink/stats/RDFStatistics.scala
+++ b/sansa-rdf-flink/src/main/scala/net/sansa_stack/rdf/flink/stats/RDFStatistics.scala
@@ -1,17 +1,13 @@
 package net.sansa_stack.rdf.flink.stats
 
-import java.io.File
 import java.io.StringWriter
 
-import scala.reflect.ClassTag
 import net.sansa_stack.rdf.flink.utils.{Logging, NodeKey}
-import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.api.java.aggregation.Aggregations
 import org.apache.flink.api.scala._
 import org.apache.flink.api.scala.DataSet
 import org.apache.flink.core.fs.FileSystem
-import org.apache.jena.graph.{Node, NodeFactory, Triple}
-import org.apache.jena.vocabulary.{OWL, RDF, RDFS, XSD}
+import org.apache.jena.graph.{Node, Triple}
+import org.apache.jena.vocabulary.{OWL, RDF, RDFS}
 
 /**
   * A Distributed implementation of RDF Statisctics using Apache Flink.

--- a/sansa-rdf-flink/src/main/scala/net/sansa_stack/rdf/flink/stats/package.scala
+++ b/sansa-rdf-flink/src/main/scala/net/sansa_stack/rdf/flink/stats/package.scala
@@ -1,11 +1,9 @@
 package net.sansa_stack.rdf.flink
 
 import net.sansa_stack.rdf.flink.utils.Logging
-import org.antlr.runtime.misc.DoubleKeyMap
 import org.apache.flink.api.scala._
 import org.apache.flink.api.scala.DataSet
 import org.apache.jena.graph.{Node, Triple}
-import org.apache.jena.vocabulary.OWL
 
 package object stats {
 

--- a/sansa-rdf-flink/src/test/scala/net/sansa_stack/rdf/flink/io/FlinkRDFLoadingTests.scala
+++ b/sansa-rdf-flink/src/test/scala/net/sansa_stack/rdf/flink/io/FlinkRDFLoadingTests.scala
@@ -1,7 +1,6 @@
 package net.sansa_stack.rdf.flink.io
 
 import org.apache.flink.api.scala.ExecutionEnvironment
-import org.apache.jena.riot.Lang
 import org.scalatest.FunSuite
 
 class FlinkRDFLoadingTests extends FunSuite {
@@ -11,7 +10,7 @@ class FlinkRDFLoadingTests extends FunSuite {
   test("loading N-Triples file into DataSet should match") {
 
     val path = getClass.getResource("/data.nt").getPath
-    val lang: Lang = Lang.NTRIPLES
+    val lang = Lang.NTRIPLES
 
     val triples = env.rdf(lang)(path)
 
@@ -23,7 +22,7 @@ class FlinkRDFLoadingTests extends FunSuite {
   test("loading N-Quads file into DataSet should match") {
 
     val path = getClass.getResource("/data.nq").getPath
-    val lang: Lang = Lang.NQUADS
+    val lang = Lang.NQUADS
 
     val triples = env.rdf(lang)(path)
 
@@ -35,7 +34,7 @@ class FlinkRDFLoadingTests extends FunSuite {
   test("loading RDF/XML file into DataSet should match") {
     val path = getClass.getResource("/data.rdf").getPath
 
-    val lang: Lang = Lang.RDFXML
+    val lang = Lang.RDFXML
     val triples = env.rdf(lang)(path)
 
     val cnt = triples.count()

--- a/sansa-rdf-flink/src/test/scala/net/sansa_stack/rdf/flink/io/FlinkRDFWritingTests.scala
+++ b/sansa-rdf-flink/src/test/scala/net/sansa_stack/rdf/flink/io/FlinkRDFWritingTests.scala
@@ -3,7 +3,6 @@ package net.sansa_stack.rdf.flink.io
 import java.nio.file.Files
 
 import org.apache.flink.api.scala.ExecutionEnvironment
-import org.apache.jena.riot.Lang
 import org.scalatest.FunSuite
 
 class FlinkRDFWritingTests extends FunSuite {
@@ -13,7 +12,7 @@ class FlinkRDFWritingTests extends FunSuite {
   test("writing N-Triples file from DataSet to disk should match") {
 
     val path = getClass.getResource("/data.nt").getPath
-    val lang: Lang = Lang.NTRIPLES
+    val lang = Lang.NTRIPLES
 
     val triples = env.rdf(lang)(path)
 

--- a/sansa-rdf-flink/src/test/scala/net/sansa_stack/rdf/flink/model/FlinkDataSetTripleOpsTests.scala
+++ b/sansa-rdf-flink/src/test/scala/net/sansa_stack/rdf/flink/model/FlinkDataSetTripleOpsTests.scala
@@ -3,7 +3,6 @@ package net.sansa_stack.rdf.flink.model
 import net.sansa_stack.rdf.flink.io._
 import org.apache.flink.api.scala.ExecutionEnvironment
 import org.apache.jena.graph.{NodeFactory, Triple}
-import org.apache.jena.riot.Lang
 import org.scalatest.FunSuite
 
 class FlinkDataSetTripleOpsTests extends FunSuite {
@@ -12,7 +11,7 @@ class FlinkDataSetTripleOpsTests extends FunSuite {
 
   test("getting all the triples should match") {
     val path = getClass.getResource("/data.nt").getPath
-    val lang: Lang = Lang.NTRIPLES
+    val lang = Lang.NTRIPLES
 
     val triples = env.rdf(lang)(path)
 
@@ -24,7 +23,7 @@ class FlinkDataSetTripleOpsTests extends FunSuite {
 
   test("getting all the subjects should match") {
     val path = getClass.getResource("/data.nt").getPath
-    val lang: Lang = Lang.NTRIPLES
+    val lang = Lang.NTRIPLES
 
     val triples = env.rdf(lang)(path)
 
@@ -36,7 +35,7 @@ class FlinkDataSetTripleOpsTests extends FunSuite {
 
   test("getting all the predicates should match") {
     val path = getClass.getResource("/data.nt").getPath
-    val lang: Lang = Lang.NTRIPLES
+    val lang = Lang.NTRIPLES
 
     val triples = env.rdf(lang)(path)
 
@@ -48,7 +47,7 @@ class FlinkDataSetTripleOpsTests extends FunSuite {
 
   test("getting all the objects should match") {
     val path = getClass.getResource("/data.nt").getPath
-    val lang: Lang = Lang.NTRIPLES
+    val lang = Lang.NTRIPLES
 
     val triples = env.rdf(lang)(path)
 
@@ -60,7 +59,7 @@ class FlinkDataSetTripleOpsTests extends FunSuite {
 
   test("filtering subjects which are URI should match") {
     val path = getClass.getResource("/data.nt").getPath
-    val lang: Lang = Lang.NTRIPLES
+    val lang = Lang.NTRIPLES
 
     val triples = env.rdf(lang)(path)
 
@@ -72,7 +71,7 @@ class FlinkDataSetTripleOpsTests extends FunSuite {
 
   test("filtering predicates which are variable should match") {
     val path = getClass.getResource("/data.nt").getPath
-    val lang: Lang = Lang.NTRIPLES
+    val lang = Lang.NTRIPLES
 
     val triples = env.rdf(lang)(path)
 
@@ -84,7 +83,7 @@ class FlinkDataSetTripleOpsTests extends FunSuite {
 
   test("filtering objects which are literals should match") {
     val path = getClass.getResource("/data.nt").getPath
-    val lang: Lang = Lang.NTRIPLES
+    val lang = Lang.NTRIPLES
 
     val triples = env.rdf(lang)(path)
 
@@ -96,7 +95,7 @@ class FlinkDataSetTripleOpsTests extends FunSuite {
 
   test("union of two RDF graph should match") {
     val path = getClass.getResource("/data.nt").getPath
-    val lang: Lang = Lang.NTRIPLES
+    val lang = Lang.NTRIPLES
 
     val triples = env.rdf(lang)(path)
 
@@ -111,7 +110,7 @@ class FlinkDataSetTripleOpsTests extends FunSuite {
 
   test("finding a statement via S, P, O to the RDF graph should match") {
     val path = getClass.getResource("/data.nt").getPath
-    val lang: Lang = Lang.NTRIPLES
+    val lang = Lang.NTRIPLES
 
     val subject = NodeFactory.createURI("http://commons.dbpedia.org/resource/Category:Events")
     val predicate = NodeFactory.createURI("http://commons.dbpedia.org/property/en")
@@ -128,7 +127,7 @@ class FlinkDataSetTripleOpsTests extends FunSuite {
 
   test("finding a statement to the RDF graph should match") {
     val path = getClass.getResource("/data.nt").getPath
-    val lang: Lang = Lang.NTRIPLES
+    val lang = Lang.NTRIPLES
 
     val triple = Triple.create(
       NodeFactory.createURI("http://commons.dbpedia.org/resource/Category:Events"),
@@ -146,7 +145,7 @@ class FlinkDataSetTripleOpsTests extends FunSuite {
 
   test("checking if the RDF graph contains any triples with a given subject and predicate should result true") {
     val path = getClass.getResource("/data.nt").getPath
-    val lang: Lang = Lang.NTRIPLES
+    val lang = Lang.NTRIPLES
 
     val subject = NodeFactory.createURI("http://commons.dbpedia.org/resource/Category:Events")
     val predicate = NodeFactory.createURI("http://commons.dbpedia.org/property/en")
@@ -160,7 +159,7 @@ class FlinkDataSetTripleOpsTests extends FunSuite {
 
   test("checks if a triple is present in the RDF graph should result true") {
     val path = getClass.getResource("/data.nt").getPath
-    val lang: Lang = Lang.NTRIPLES
+    val lang = Lang.NTRIPLES
 
     val triple = Triple.create(
       NodeFactory.createURI("http://commons.dbpedia.org/resource/Category:Events"),

--- a/sansa-rdf-flink/src/test/scala/net/sansa_stack/rdf/flink/model/FlinkGraphTripleOpsTests.scala
+++ b/sansa-rdf-flink/src/test/scala/net/sansa_stack/rdf/flink/model/FlinkGraphTripleOpsTests.scala
@@ -15,7 +15,7 @@ class FlinkGraphTripleOpsTests extends FunSuite {
 
     val triples = env.rdf(lang)(path)
 
-    val graph = triples.asGraph()
+    // val graph = triples.asGraph()
 
     // val size = graph.size()
 

--- a/sansa-rdf-flink/src/test/scala/net/sansa_stack/rdf/flink/model/FlinkGraphTripleOpsTests.scala
+++ b/sansa-rdf-flink/src/test/scala/net/sansa_stack/rdf/flink/model/FlinkGraphTripleOpsTests.scala
@@ -1,11 +1,7 @@
 package net.sansa_stack.rdf.flink.model
 
-import net.sansa_stack.rdf.common.kryo.jena.JenaKryoSerializers._
 import net.sansa_stack.rdf.flink.io._
-import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.scala.ExecutionEnvironment
-import org.apache.jena.graph.Node
-import org.apache.jena.riot.Lang
 import org.scalatest.FunSuite
 
 class FlinkGraphTripleOpsTests extends FunSuite {
@@ -14,22 +10,12 @@ class FlinkGraphTripleOpsTests extends FunSuite {
   test("constructing the Graph from DataSet should match") {
 
     val path = getClass.getResource("/data.nt").getPath
-    val lang: Lang = Lang.NTRIPLES
+    val lang = Lang.NTRIPLES
 
-    import org.apache.flink.api.scala._
-
-    val nodeInfo: TypeInformation[Node] = createTypeInformation[Node]
-    nodeInfo.createSerializer(env.getConfig)
-    env.getConfig.enableForceKryo()
 
     val triples = env.rdf(lang)(path)
 
-    env.getConfig.addDefaultKryoSerializer(classOf[Node], classOf[NodeSerializer])
-    env.registerTypeWithKryoSerializer(classOf[Node], classOf[NodeSerializer])
-    env.registerTypeWithKryoSerializer(classOf[org.apache.jena.graph.Node], classOf[NodeSerializer])
-    env.registerTypeWithKryoSerializer(classOf[Array[org.apache.jena.graph.Node]], classOf[NodeSerializer])
-
-    // val graph = triples.asGraph()
+    val graph = triples.asGraph()
 
     // val size = graph.size()
 

--- a/sansa-rdf-flink/src/test/scala/net/sansa_stack/rdf/flink/partition/FlinkSparqlifyPartitionTests.scala
+++ b/sansa-rdf-flink/src/test/scala/net/sansa_stack/rdf/flink/partition/FlinkSparqlifyPartitionTests.scala
@@ -2,7 +2,6 @@ package net.sansa_stack.rdf.flink.partition
 
 import net.sansa_stack.rdf.flink.io._
 import org.apache.flink.api.scala.ExecutionEnvironment
-import org.apache.jena.riot.Lang
 import org.scalatest.FunSuite
 
 class FlinkSparqlifyPartitionTests extends FunSuite {
@@ -11,7 +10,7 @@ class FlinkSparqlifyPartitionTests extends FunSuite {
 
   test("partitioning N-Triples file into Sparqlify Partition (Vertical Partition) should match") {
     val path = getClass.getResource("/data.nt").getPath
-    val lang: Lang = Lang.NTRIPLES
+    val lang = Lang.NTRIPLES
 
     val triples = env.rdf(lang)(path)
 

--- a/sansa-rdf-flink/src/test/scala/net/sansa_stack/rdf/flink/qualityassessment/metrics/FlinkAvailabilityTests.scala
+++ b/sansa-rdf-flink/src/test/scala/net/sansa_stack/rdf/flink/qualityassessment/metrics/FlinkAvailabilityTests.scala
@@ -2,7 +2,6 @@ package net.sansa_stack.rdf.flink.qualityassessment.metrics
 
 import net.sansa_stack.rdf.flink.io._
 import org.apache.flink.api.scala.ExecutionEnvironment
-import org.apache.jena.riot.Lang
 import org.scalatest.FunSuite
 
 class FlinkAvailabilityTests extends FunSuite {
@@ -14,7 +13,7 @@ class FlinkAvailabilityTests extends FunSuite {
   test("getting the Dereferenceable URIs should match") {
 
     val path = getClass.getResource("/data.nt").getPath
-    val lang: Lang = Lang.NTRIPLES
+    val lang = Lang.NTRIPLES
 
     val triples = env.rdf(lang)(path)
 
@@ -25,7 +24,7 @@ class FlinkAvailabilityTests extends FunSuite {
   test("getting the Dereferenceable BackLinks should match") {
 
     val path = getClass.getResource("/data.nt").getPath
-    val lang: Lang = Lang.NTRIPLES
+    val lang = Lang.NTRIPLES
 
     val triples = env.rdf(lang)(path)
 
@@ -36,7 +35,7 @@ class FlinkAvailabilityTests extends FunSuite {
   test("getting the Dereferenceable ForwardLinks should match") {
 
     val path = getClass.getResource("/data.nt").getPath
-    val lang: Lang = Lang.NTRIPLES
+    val lang = Lang.NTRIPLES
 
     val triples = env.rdf(lang)(path)
 

--- a/sansa-rdf-flink/src/test/scala/net/sansa_stack/rdf/flink/qualityassessment/metrics/FlinkCompletenessTests.scala
+++ b/sansa-rdf-flink/src/test/scala/net/sansa_stack/rdf/flink/qualityassessment/metrics/FlinkCompletenessTests.scala
@@ -2,7 +2,6 @@ package net.sansa_stack.rdf.flink.qualityassessment.metrics
 
 import net.sansa_stack.rdf.flink.io._
 import org.apache.flink.api.scala.ExecutionEnvironment
-import org.apache.jena.riot.Lang
 import org.scalatest.FunSuite
 
 class FlinkCompletenessTests extends FunSuite {
@@ -14,7 +13,7 @@ class FlinkCompletenessTests extends FunSuite {
   test("assessing the Interlinking Completeness should match") {
 
     val path = getClass.getResource("/data.nt").getPath
-    val lang: Lang = Lang.NTRIPLES
+    val lang = Lang.NTRIPLES
 
     val triples = env.rdf(lang)(path)
 
@@ -25,7 +24,7 @@ class FlinkCompletenessTests extends FunSuite {
   test("assessing the Property Completeness should match") {
 
     val path = getClass.getResource("/data.nt").getPath
-    val lang: Lang = Lang.NTRIPLES
+    val lang = Lang.NTRIPLES
 
     val triples = env.rdf(lang)(path)
 
@@ -36,7 +35,7 @@ class FlinkCompletenessTests extends FunSuite {
   test("assessing the Schema Completeness should match") {
 
     val path = getClass.getResource("/data.nt").getPath
-    val lang: Lang = Lang.NTRIPLES
+    val lang = Lang.NTRIPLES
 
     val triples = env.rdf(lang)(path)
 

--- a/sansa-rdf-flink/src/test/scala/net/sansa_stack/rdf/flink/qualityassessment/metrics/FlinkLicensingTests.scala
+++ b/sansa-rdf-flink/src/test/scala/net/sansa_stack/rdf/flink/qualityassessment/metrics/FlinkLicensingTests.scala
@@ -2,7 +2,6 @@ package net.sansa_stack.rdf.flink.qualityassessment.metrics
 
 import net.sansa_stack.rdf.flink.io._
 import org.apache.flink.api.scala.ExecutionEnvironment
-import org.apache.jena.riot.Lang
 import org.scalatest.FunSuite
 
 class FlinkLicensingTests extends FunSuite {
@@ -14,7 +13,7 @@ class FlinkLicensingTests extends FunSuite {
   test("assessing the human readable license should match") {
 
     val path = getClass.getResource("/data.nt").getPath
-    val lang: Lang = Lang.NTRIPLES
+    val lang = Lang.NTRIPLES
 
     val triples = env.rdf(lang)(path)
 
@@ -25,7 +24,7 @@ class FlinkLicensingTests extends FunSuite {
   test("assessing the machine readable license should match") {
 
     val path = getClass.getResource("/data.nt").getPath
-    val lang: Lang = Lang.NTRIPLES
+    val lang = Lang.NTRIPLES
 
     val triples = env.rdf(lang)(path)
 

--- a/sansa-rdf-flink/src/test/scala/net/sansa_stack/rdf/flink/qualityassessment/metrics/FlinkPerformanceTests.scala
+++ b/sansa-rdf-flink/src/test/scala/net/sansa_stack/rdf/flink/qualityassessment/metrics/FlinkPerformanceTests.scala
@@ -2,7 +2,6 @@ package net.sansa_stack.rdf.flink.qualityassessment.metrics
 
 import net.sansa_stack.rdf.flink.io._
 import org.apache.flink.api.scala.ExecutionEnvironment
-import org.apache.jena.riot.Lang
 import org.scalatest.FunSuite
 
 class FlinkPerformanceTests extends FunSuite {
@@ -14,7 +13,7 @@ class FlinkPerformanceTests extends FunSuite {
   test("assessing the not hash URIs should result in value 0.0") {
 
     val path = getClass.getResource("/data.nt").getPath
-    val lang: Lang = Lang.NTRIPLES
+    val lang = Lang.NTRIPLES
 
     val triples = env.rdf(lang)(path)
 

--- a/sansa-rdf-flink/src/test/scala/net/sansa_stack/rdf/flink/qualityassessment/metrics/FlinkRelevancyTests.scala
+++ b/sansa-rdf-flink/src/test/scala/net/sansa_stack/rdf/flink/qualityassessment/metrics/FlinkRelevancyTests.scala
@@ -2,7 +2,6 @@ package net.sansa_stack.rdf.flink.qualityassessment.metrics
 
 import net.sansa_stack.rdf.flink.io._
 import org.apache.flink.api.scala.ExecutionEnvironment
-import org.apache.jena.riot.Lang
 import org.scalatest.FunSuite
 
 class FlinkRelevancyTests extends FunSuite {
@@ -14,7 +13,7 @@ class FlinkRelevancyTests extends FunSuite {
   test("assessing the amount of triples should match") {
 
     val path = getClass.getResource("/data.nt").getPath
-    val lang: Lang = Lang.NTRIPLES
+    val lang = Lang.NTRIPLES
 
     val triples = env.rdf(lang)(path)
 
@@ -25,7 +24,7 @@ class FlinkRelevancyTests extends FunSuite {
   test("assessing the coverage scope of a dataset should match") {
 
     val path = getClass.getResource("/data.nt").getPath
-    val lang: Lang = Lang.NTRIPLES
+    val lang = Lang.NTRIPLES
 
     val triples = env.rdf(lang)(path)
 
@@ -36,7 +35,7 @@ class FlinkRelevancyTests extends FunSuite {
   test("assessing the coverage details of a dataset should match") {
 
     val path = getClass.getResource("/data.nt").getPath
-    val lang: Lang = Lang.NTRIPLES
+    val lang = Lang.NTRIPLES
 
     val triples = env.rdf(lang)(path)
 

--- a/sansa-rdf-flink/src/test/scala/net/sansa_stack/rdf/flink/qualityassessment/metrics/FlinkReprconcisenessTests.scala
+++ b/sansa-rdf-flink/src/test/scala/net/sansa_stack/rdf/flink/qualityassessment/metrics/FlinkReprconcisenessTests.scala
@@ -2,7 +2,6 @@ package net.sansa_stack.rdf.flink.qualityassessment.metrics
 
 import net.sansa_stack.rdf.flink.io._
 import org.apache.flink.api.scala.ExecutionEnvironment
-import org.apache.jena.riot.Lang
 import org.scalatest.FunSuite
 
 class FlinkReprconcisenessTests extends FunSuite {
@@ -14,7 +13,7 @@ class FlinkReprconcisenessTests extends FunSuite {
   test("assessing the query param free URIs should match") {
 
     val path = getClass.getResource("/data.nt").getPath
-    val lang: Lang = Lang.NTRIPLES
+    val lang = Lang.NTRIPLES
 
     val triples = env.rdf(lang)(path)
 
@@ -25,7 +24,7 @@ class FlinkReprconcisenessTests extends FunSuite {
   test("assessing the short URIs should match") {
 
     val path = getClass.getResource("/data.nt").getPath
-    val lang: Lang = Lang.NTRIPLES
+    val lang = Lang.NTRIPLES
 
     val triples = env.rdf(lang)(path)
 

--- a/sansa-rdf-flink/src/test/scala/net/sansa_stack/rdf/flink/qualityassessment/metrics/FlinkSyntacticvalidityTests.scala
+++ b/sansa-rdf-flink/src/test/scala/net/sansa_stack/rdf/flink/qualityassessment/metrics/FlinkSyntacticvalidityTests.scala
@@ -2,7 +2,6 @@ package net.sansa_stack.rdf.flink.qualityassessment.metrics
 
 import net.sansa_stack.rdf.flink.io._
 import org.apache.flink.api.scala.ExecutionEnvironment
-import org.apache.jena.riot.Lang
 import org.scalatest.FunSuite
 
 class FlinkSyntacticvalidityTests extends FunSuite {
@@ -14,7 +13,7 @@ class FlinkSyntacticvalidityTests extends FunSuite {
   test("assessing the literal numeric range checker should match") {
 
     val path = getClass.getResource("/data.nt").getPath
-    val lang: Lang = Lang.NTRIPLES
+    val lang = Lang.NTRIPLES
 
     val triples = env.rdf(lang)(path)
 
@@ -25,7 +24,7 @@ class FlinkSyntacticvalidityTests extends FunSuite {
   test("assessing the XSD datatype compatible literals should match") {
 
     val path = getClass.getResource("/data.nt").getPath
-    val lang: Lang = Lang.NTRIPLES
+    val lang = Lang.NTRIPLES
 
     val triples = env.rdf(lang)(path)
 

--- a/sansa-rdf-flink/src/test/scala/net/sansa_stack/rdf/flink/qualityassessment/metrics/FlinkUnderstandabilityTests.scala
+++ b/sansa-rdf-flink/src/test/scala/net/sansa_stack/rdf/flink/qualityassessment/metrics/FlinkUnderstandabilityTests.scala
@@ -2,7 +2,6 @@ package net.sansa_stack.rdf.flink.qualityassessment.metrics
 
 import net.sansa_stack.rdf.flink.io._
 import org.apache.flink.api.scala.ExecutionEnvironment
-import org.apache.jena.riot.Lang
 import org.scalatest.FunSuite
 
 class FlinkUnderstandabilityTests extends FunSuite {
@@ -14,7 +13,7 @@ class FlinkUnderstandabilityTests extends FunSuite {
   test("assessing the labeled resources should match") {
 
     val path = getClass.getResource("/data.nt").getPath
-    val lang: Lang = Lang.NTRIPLES
+    val lang = Lang.NTRIPLES
 
     val triples = env.rdf(lang)(path)
 

--- a/sansa-rdf-flink/src/test/scala/net/sansa_stack/rdf/flink/stats/FlinkRDFStatsTests.scala
+++ b/sansa-rdf-flink/src/test/scala/net/sansa_stack/rdf/flink/stats/FlinkRDFStatsTests.scala
@@ -1,14 +1,11 @@
 package net.sansa_stack.rdf.flink.stats
 
 import net.sansa_stack.rdf.flink.io._
-import org.apache.flink.api.scala._
 import org.apache.flink.api.scala.ExecutionEnvironment
-import org.apache.jena.riot.Lang
 import org.scalatest.FunSuite
 
 class FlinkRDFStatsTests extends FunSuite {
 
-  import net.sansa_stack.rdf.flink.stats._
 
   val env = ExecutionEnvironment.getExecutionEnvironment
 


### PR DESCRIPTION
This PR proposes a change w.r.t to the usage of the Lang when reading the triples.

The simples `NTRIPLES` reader would change from: 
```scala
import net.sansa_stack.rdf.flink.io._
import org.apache.jena.riot.Lang

val lang: Lang = Lang.NTRIPLES

val triples = env.rdf(lang)(path)
```
to
```scala
import net.sansa_stack.rdf.flink.io._

val lang = Lang.NTRIPLES

val triples = env.rdf(lang)(path)
```

I'm not sure if we are going to lose some of the [Lang functionality](https://jena.apache.org/documentation/javadoc/arq/org/apache/jena/riot/Lang.html) but AFIK it hasn't been used for such purpose (only `getLabel` when the syntax/serialization isn't supported).

Feel free to comment, suggest changes, and discusses this change as we may need to align spark-module as well.

Best regards,