### PR TITLE
Feature rddopsclaus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,7 @@
     </properties>
 
     <modules>
+        <module>sansa-test-resources</module>
         <module>sansa-resource-metadata</module>
         <module>sansa-resource-testdata</module>
         <module>sansa-rdf</module>
@@ -134,6 +135,13 @@
 
     <dependencyManagement>
         <dependencies>
+
+            <dependency>
+                <groupId>net.sansa-stack</groupId>
+                <artifactId>sansa-test-resources_${scala.binary.version}</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
             <!-- General SANSA metadata file (build time / version) -->
             <dependency>
                 <groupId>net.sansa-stack</groupId>
@@ -1181,6 +1189,13 @@
                 <artifactId>slf4j-api</artifactId>
                 <version>1.7.30</version>
             </dependency>
+
+        <dependency>
+                <groupId>org.slf4j</groupId>
+<artifactId>slf4j-log4j12</artifactId>
+		<version>1.7.30</version>
+        </dependency>
+
 
             <dependency>
                 <groupId>org.eclipse.rdf4j</groupId>

--- a/sansa-rdf/sansa-rdf-common/pom.xml
+++ b/sansa-rdf/sansa-rdf-common/pom.xml
@@ -127,6 +127,12 @@
 			<artifactId>jsqlparser</artifactId>
 		</dependency>
 
+        <dependency>
+            <groupId>net.sansa-stack</groupId>
+            <artifactId>sansa-test-resources_${scala.binary.version}</artifactId>
+            <scope>test</scope>
+        </dependency>
+
 	</dependencies>
 
 	<build>

--- a/sansa-rdf/sansa-rdf-common/src/main/java/net/sansa_stack/rdf/common/InterruptingReadableByteChannel.java
+++ b/sansa-rdf/sansa-rdf-common/src/main/java/net/sansa_stack/rdf/common/InterruptingReadableByteChannel.java
@@ -7,6 +7,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
+import java.util.concurrent.Callable;
+import java.util.function.Consumer;
 
 /** ReadabalByteChannel whose read method is guaranteed to return at a specific position
  *  (before crossing it) such as a split boundary
@@ -19,14 +21,26 @@ public class InterruptingReadableByteChannel
     protected InputStream in;
     protected Seekable seekable;
     protected long interruptPos;
+    protected long bytesRead = 0;
+    protected Consumer<InterruptingReadableByteChannel> interruptPosFoundCallback;
+
 
     public InterruptingReadableByteChannel(
             InputStream in,
             Seekable seekable,
             long interruptPos) {
+        this(in, seekable, interruptPos, null);
+    }
+
+    public InterruptingReadableByteChannel(
+            InputStream in,
+            Seekable seekable,
+            long interruptPos,
+            Consumer<InterruptingReadableByteChannel> interruptPosFoundCallback) {
         this.in = in;
         this.seekable = seekable;
         this.interruptPos = interruptPos;
+        this.interruptPosFoundCallback = interruptPosFoundCallback;
     }
 
     @Override
@@ -43,14 +57,22 @@ public class InterruptingReadableByteChannel
         int contrib = in.read(buffer, 0, toRead);
 
         if (contrib >= 0) {
+            bytesRead += contrib;
             byteBuffer.put(buffer, 0, contrib);
         }
 
         if (pos == interruptPos) {
             interrupted = true;
+            if (interruptPosFoundCallback != null) {
+                interruptPosFoundCallback.accept(this);
+            }
         }
 
         return contrib;
+    }
+
+    public long getBytesRead() {
+        return bytesRead;
     }
 
     @Override

--- a/sansa-rdf/sansa-rdf-common/src/main/java/net/sansa_stack/rdf/common/ReadableByteChannelWithoutCloseOnInterrupt.java
+++ b/sansa-rdf/sansa-rdf-common/src/main/java/net/sansa_stack/rdf/common/ReadableByteChannelWithoutCloseOnInterrupt.java
@@ -5,15 +5,16 @@ import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 
-// ReadableByteChannelImpl2 without the Interruptible stuff
-public class ReadableByteChannelImpl2
+/** ReadableByteChannel from an InputStream without closing the stream on interrupt as
+ * Channels.newChannel does. */
+public class ReadableByteChannelWithoutCloseOnInterrupt
         implements ReadableByteChannel {
     InputStream in;
     private static final int TRANSFER_SIZE = 8192;
     private byte buf[] = new byte[0];
     private boolean open = true;
 
-    public ReadableByteChannelImpl2(InputStream in) {
+    public ReadableByteChannelWithoutCloseOnInterrupt(InputStream in) {
         this.in = in;
     }
 

--- a/sansa-rdf/sansa-rdf-common/src/main/java/net/sansa_stack/rdf/common/io/hadoop/TrigFileInputFormat.java
+++ b/sansa-rdf/sansa-rdf-common/src/main/java/net/sansa_stack/rdf/common/io/hadoop/TrigFileInputFormat.java
@@ -143,8 +143,8 @@ public class TrigFileInputFormat
 
         long maxPrefixesBytes = job.getLong(PARSED_PREFIXES_LENGTH, PARSED_PREFIXES_LENGTH_DEFAULT);
         if (maxPrefixesBytes > end) {
-            logger.warn("Number of bytes set for prefixes parsing ($maxPrefixesBytes) larger than the size of the first" +
-                    " split ($end). Could be slow");
+            logger.warn(String.format("Number of bytes set for prefixes parsing (%d) larger than the size of the first" +
+                    " split (%d). Could be slow", maxPrefixesBytes, end));
         }
         end = Math.max(end, maxPrefixesBytes);
 

--- a/sansa-rdf/sansa-rdf-common/src/test/java/net/sansa_stack/rdf/common/io/hadoop/TrigRecordReaderTestBase.java
+++ b/sansa-rdf/sansa-rdf-common/src/test/java/net/sansa_stack/rdf/common/io/hadoop/TrigRecordReaderTestBase.java
@@ -2,7 +2,6 @@ package net.sansa_stack.rdf.common.io.hadoop;
 
 import com.google.common.collect.*;
 import org.aksw.jena_sparql_api.utils.DatasetGraphUtils;
-import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
@@ -15,7 +14,6 @@ import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.query.DatasetFactory;
-import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
 import org.junit.Assert;
 import org.junit.Test;
@@ -41,35 +39,15 @@ import java.util.stream.IntStream;
  * @author Lorenz Buehmann
  * @author Claus Stadler
  */
-@RunWith(Parameterized.class)
-public class TrigRecordReaderTest {
+public class TrigRecordReaderTestBase {
 
-    private static final Logger logger = LoggerFactory.getLogger(TrigRecordReaderTest.class);
+    private static final Logger logger = LoggerFactory.getLogger(TrigRecordReaderTestBase.class);
 
-    /**
-     * Test case parameters
-     *
-     * @return
-     */
-    @Parameterized.Parameters(name = "{index}: file {0} with {1} splits")
-    public static Iterable<Object[]> data() {
-        // The map of test cases:
-        // Each file is mapped to the number of  min splits and max splits(both inclusive)
-        Map<String, Range<Integer>> params = new LinkedHashMap<>();
-
-        params.put("src/test/resources/nato-phonetic-alphabet-example.trig",
-                Range.closed(1, 5));
-
-        params.put("src/test/resources/nato-phonetic-alphabet-example.trig.bz2",
-                Range.closed(1, 5));
-
-        // Slow test
-        // params.put("../../sansa-resource-testdata/src/main/resources/hobbit-sensor-stream-150k-events-data.trig.bz2",
-        //        Range.closed(1, 5));
+    public static List<Object[]> createParameters(Map<String, Range<Integer>> fileToNumSplits) {
 
         // Post process the map into junit params by enumerating the ranges
         // and creating a test case for each obtained value
-        List<Object[]> result = params.entrySet().stream()
+        List<Object[]> result = fileToNumSplits.entrySet().stream()
                 .flatMap(e -> ContiguousSet.create(e.getValue(), DiscreteDomain.integers()).stream()
                         .map(numSplits -> new Object[]{e.getKey(), numSplits}))
                 .collect(Collectors.toList());
@@ -80,7 +58,7 @@ public class TrigRecordReaderTest {
     protected String file;
     protected int numSplits;
 
-    public TrigRecordReaderTest(String file, int numSplits) {
+    public TrigRecordReaderTestBase(String file, int numSplits) {
         this.file = file;
         this.numSplits = numSplits;
     }

--- a/sansa-rdf/sansa-rdf-common/src/test/java/net/sansa_stack/rdf/common/io/hadoop/TrigRecordReaderTestsFast.java
+++ b/sansa-rdf/sansa-rdf-common/src/test/java/net/sansa_stack/rdf/common/io/hadoop/TrigRecordReaderTestsFast.java
@@ -1,0 +1,37 @@
+package net.sansa_stack.rdf.common.io.hadoop;
+
+import com.google.common.collect.Range;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@RunWith(Parameterized.class)
+public class TrigRecordReaderTestsFast
+    extends TrigRecordReaderTestBase
+{
+    public TrigRecordReaderTestsFast(String file, int numSplits) {
+        super(file, numSplits);
+    }
+
+    /**
+     * Test case parameters
+     *
+     * @return
+     */
+    @Parameterized.Parameters(name = "{index}: file {0} with {1} splits")
+    public static Iterable<Object[]> data() {
+        // The map of test cases:
+        // Each file is mapped to the number of  min splits and max splits(both inclusive)
+        Map<String, Range<Integer>> map = new LinkedHashMap<>();
+
+        map.put("src/test/resources/nato-phonetic-alphabet-example.trig",
+                Range.closed(1, 5));
+
+        map.put("src/test/resources/nato-phonetic-alphabet-example.trig.bz2",
+                Range.closed(1, 5));
+
+        return TrigRecordReaderTestBase.createParameters(map);
+    }
+}

--- a/sansa-rdf/sansa-rdf-common/src/test/java/net/sansa_stack/rdf/common/io/hadoop/TrigRecordReaderTestsSlow.java
+++ b/sansa-rdf/sansa-rdf-common/src/test/java/net/sansa_stack/rdf/common/io/hadoop/TrigRecordReaderTestsSlow.java
@@ -1,0 +1,34 @@
+package net.sansa_stack.rdf.common.io.hadoop;
+
+import com.google.common.collect.Range;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@RunWith(Parameterized.class)
+// @Category()
+public class TrigRecordReaderTestsSlow
+    extends TrigRecordReaderTestBase
+{
+    public TrigRecordReaderTestsSlow(String file, int numSplits) {
+        super(file, numSplits);
+    }
+
+    /**
+     * Test case parameters
+     *
+     * @return
+     */
+    @Parameterized.Parameters(name = "{index}: file {0} with {1} splits")
+    public static Iterable<Object[]> data() {
+        Map<String, Range<Integer>> map = new LinkedHashMap<>();
+
+        // Slow test
+        map.put("../../sansa-resource-testdata/src/main/resources/hobbit-sensor-stream-150k-events-data.trig.bz2",
+                Range.closed(1, 5));
+
+        return TrigRecordReaderTestBase.createParameters(map);
+    }
+}

--- a/sansa-rdf/sansa-rdf-common/src/test/java/net/sansa_stack/rdf/common/io/hadoop/TrigRecordReaderTestsSlow.java
+++ b/sansa-rdf/sansa-rdf-common/src/test/java/net/sansa_stack/rdf/common/io/hadoop/TrigRecordReaderTestsSlow.java
@@ -7,7 +7,7 @@ import org.junit.runners.Parameterized;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-@RunWith(Parameterized.class)
+// @RunWith(Parameterized.class)
 // @Category()
 public class TrigRecordReaderTestsSlow
     extends TrigRecordReaderTestBase

--- a/sansa-rdf/sansa-rdf-common/src/test/resources/log4j.properties
+++ b/sansa-rdf/sansa-rdf-common/src/test/resources/log4j.properties
@@ -1,8 +1,0 @@
-# Root logger option
-log4j.rootLogger=INFO, stdout
-
-# Direct log messages to stdout
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.Target=System.out
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n

--- a/sansa-test-resources/README.md
+++ b/sansa-test-resources/README.md
@@ -1,0 +1,3 @@
+Resources common to all modules with scope 'test'.
+Most prominently a common log4j.properties file.
+

--- a/sansa-test-resources/pom.xml
+++ b/sansa-test-resources/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>net.sansa-stack</groupId>
+        <artifactId>sansa-parent_2.12</artifactId>
+        <version>0.7.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>sansa-test-resources_2.12</artifactId>
+    <packaging>jar</packaging>
+
+
+    <dependencies>
+<!--
+	<dependency>
+		<groupId>org.slf4j</groupId>
+<artifactId>slf4j-log4j12</artifactId>
+	</dependency>
+-->
+    </dependencies>
+
+</project>
+

--- a/sansa-test-resources/src/main/resources/log4j.properties
+++ b/sansa-test-resources/src/main/resources/log4j.properties
@@ -1,0 +1,10 @@
+# Root logger option
+log4j.rootLogger=INFO, stderr
+
+# Direct log messages to stderr
+log4j.appender.stderr=org.apache.log4j.ConsoleAppender
+log4j.appender.stderr.Target=System.err
+log4j.appender.stderr.layout=org.apache.log4j.PatternLayout
+log4j.appender.stderr.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+
+


### PR DESCRIPTION
Updated trig record reader to handle the corner case where a record belonging to the 'head' region is found near the end of a split such that probing has to pass the split boundary. The old version cut probing off which could lead to loss of records. This version allows the head-buffer - on which probing is performed - to span into the next split.